### PR TITLE
Add setOutput method to capture Python output

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ To avoid blocking the main UI thread, we run pyodide in a background web worker
 
 https://pyodide.org/en/stable/usage/webworker.html
 
+## Capturing python output
+
+You can capture output from Python's print statements and error messages using `setOutput`. Pass a callback function that will be called with each piece of output text:
+
+```
+// Simple logging
+pyodide.setOutput((text) => {
+  console.log('Python output:', text);
+});
+```
+
+Read more redirecting standard streams in pyodide here:
+
+https://pyodide.org/en/stable/usage/streams.html
+
 ## Accessing outside React
 
 If needed, you can access pyodide outside of React components like this:

--- a/src/pyodide-api.ts
+++ b/src/pyodide-api.ts
@@ -16,6 +16,7 @@ export interface Pyodide {
     code: string,
     globals?: Record<string, JSONValue>
   ) => Promise<JSONValue | null>;
+  setOutput: (callback: ((text: string) => void) | null) => void;
   terminate: () => void;
 }
 
@@ -32,6 +33,7 @@ export const initializeWorker = async (packages?: string[]): Promise<Pyodide> =>
   return {
     runPython,
     runPythonJson,
+    setOutput,
     terminate,
   };
 };
@@ -65,6 +67,16 @@ const runPythonJson = async (
   }
 
   return null;
+};
+
+/**
+ * Redirect Pyodide output stream.
+ */
+const setOutput = (callback: ((text: string) => void) | null): void => {
+  if (!_runner) {
+    throw new Error("pyodide isn't loaded yet");
+  }
+  _runner.setOutput(Comlink.proxy(callback));
 };
 
 /**

--- a/src/pyodide-worker.ts
+++ b/src/pyodide-worker.ts
@@ -22,7 +22,6 @@ declare global {
 let _pyodideReady: Promise<void> | null = null;
 let _output: ((text: string) => void) | null = null;
 
-
 /**
  * Initialize pyodide and set a singleton promise to await it being ready.
  * This should only be called once.


### PR DESCRIPTION
Hey Matt, great hook!

This adds the ability to capture output from Python code execution using a new `setOutput` method. This allows users to handle print statements and error messages from their Python code and e.g. redirect them to a component, state manager, or specific message. (Read here: https://pyodide.org/en/stable/usage/streams.html)

Not too many changes:
- Added `setOutput` method to Pyodide interface
- Implemented output capture in web worker
- Added brief documentation in README

Example usage:
```typescript
// Simple logging
pyodide.setOutput((text) => {
  console.log('Python output:', text);
});

// Accumulate output in React state
pyodide.setOutput((text) => {
  setConsoleOutput((prevOutput) => 
    prevOutput ? prevOutput + "\n" + text : text
  );
});
```

This captures both stdout and stderr through a single callback, making it easy to display Python output in the UI or console. A future iteration may allow users to separate stdout & stderr.